### PR TITLE
Updating dockerfile to include explicit copy of python script

### DIFF
--- a/segmentation_testbed/dockerfile
+++ b/segmentation_testbed/dockerfile
@@ -8,6 +8,7 @@ RUN python3 -m pip install numpy
 
 LABEL maintainer="jsolly"
 WORKDIR /project/inputs
+COPY ./inputs/ /project/inputs/segmentation_testbed_2.py
 RUN mkdir ../outputs
 
 CMD ["python3", "segmentation_testbed_2.py", "-f", "LC08_L1TP_001028_20220615_20220627_02_T1_mosaic.tif"]


### PR DESCRIPTION
To help bypass the error when running the job on Bacalhau:
`python3: can't open file '/project/inputs/segmentation_testbed_2.py': [Errno 2] No such file or directory`
